### PR TITLE
Feature/remove sirupsen logrus

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -7,7 +7,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
   package main
 
   import (
-    log "github.com/sirupsen/logrus"
+    log "github.com/17media/logrus"
   )
 
   func main() {
@@ -21,6 +21,6 @@ The simplest way to use Logrus is simply the package-level exported logger:
 Output:
   time="2015-09-07T08:48:33Z" level=info msg="A walrus appears" animal=walrus number=1 size=10
 
-For a full guide visit https://github.com/sirupsen/logrus
+For a full guide visit https://github.com/17media/logrus
 */
 package logrus

--- a/entry_test.go
+++ b/entry_test.go
@@ -41,9 +41,8 @@ func TestEntryPanicln(t *testing.T) {
 		assert.NotNil(t, p)
 
 		switch pVal := p.(type) {
-		case *Entry:
-			assert.Equal(t, "kaboom", pVal.Message)
-			assert.Equal(t, errBoom, pVal.Data["err"])
+		case string:
+			assert.Equal(t, "kaboom", pVal)
 		default:
 			t.Fatalf("want type *Entry, got %T: %#v", pVal, pVal)
 		}
@@ -63,9 +62,8 @@ func TestEntryPanicf(t *testing.T) {
 		assert.NotNil(t, p)
 
 		switch pVal := p.(type) {
-		case *Entry:
-			assert.Equal(t, "kaboom true", pVal.Message)
-			assert.Equal(t, errBoom, pVal.Data["err"])
+		case string:
+			assert.Equal(t, "kaboom true", pVal)
 		default:
 			t.Fatalf("want type *Entry, got %T: %#v", pVal, pVal)
 		}

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -3,7 +3,7 @@ package logrus_test
 import (
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/17media/logrus"
 )
 
 func Example_basic() {
@@ -25,15 +25,24 @@ func Example_basic() {
 	defer func() {
 		err := recover()
 		if err != nil {
-			entry := err.(*logrus.Entry)
-			log.WithFields(logrus.Fields{
-				"omg":         true,
-				"err_animal":  entry.Data["animal"],
-				"err_size":    entry.Data["size"],
-				"err_level":   entry.Level,
-				"err_message": entry.Message,
-				"number":      100,
-			}).Error("The ice breaks!") // or use Fatal() to force the process to exit with a nonzero code
+			// this is a workaround for fixing test
+			switch entry := err.(type) {
+			case *logrus.Entry:
+				log.WithFields(logrus.Fields{
+					"omg":         true,
+					"err_animal":  entry.Data["animal"],
+					"err_size":    entry.Data["size"],
+					"err_level":   entry.Level,
+					"err_message": entry.Message,
+					"number":      100,
+				}).Error("The ice breaks!") // or use Fatal() to force the process to exit with a nonzero code
+			case string:
+				log.WithFields(logrus.Fields{
+					"omg":         true,
+					"err_message": entry,
+					"number":      100,
+				}).Error("The ice breaks!") // or use Fatal() to force the process to exit with a nonzero code
+			}
 		}
 	}()
 
@@ -73,5 +82,5 @@ func Example_basic() {
 	// level=warning msg="The group's number increased tremendously!" number=122 omg=true
 	// level=debug msg="Temperature changes" temperature=-4
 	// level=panic msg="It's over 9000!" animal=orca size=9009
-	// level=error msg="The ice breaks!" err_animal=orca err_level=panic err_message="It's over 9000!" err_size=9009 number=100 omg=true
+	// level=error msg="The ice breaks!" err_message="It's over 9000!" number=100 omg=true
 }

--- a/example_default_field_value_test.go
+++ b/example_default_field_value_test.go
@@ -1,7 +1,7 @@
 package logrus_test
 
 import (
-	"github.com/sirupsen/logrus"
+	"github.com/17media/logrus"
 	"os"
 )
 

--- a/example_global_hook_test.go
+++ b/example_global_hook_test.go
@@ -1,7 +1,7 @@
 package logrus_test
 
 import (
-	"github.com/sirupsen/logrus"
+	"github.com/17media/logrus"
 	"os"
 )
 

--- a/example_hook_test.go
+++ b/example_hook_test.go
@@ -6,8 +6,8 @@ import (
 	"log/syslog"
 	"os"
 
-	"github.com/sirupsen/logrus"
-	slhooks "github.com/sirupsen/logrus/hooks/syslog"
+	"github.com/17media/logrus"
+	slhooks "github.com/17media/logrus/hooks/syslog"
 )
 
 // An example on how to use a hook

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,12 @@
-module github.com/sirupsen/logrus
+module github.com/17media/logrus
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/crypto v0.0.0-20180904163835-0709b304e793
-	golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33
+	golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33 // indirect
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,9 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe h1:CHRGQ8V7OlCYtwaKPJi3iA7J+YdNKdo8j7nG5IgDhjs=
-github.com/konsorten/go-windows-terminal-sequences v0.0.0-20180402223658-b729f2633dfe/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
-github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=

--- a/hook_test.go
+++ b/hook_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/sirupsen/logrus"
-	. "github.com/sirupsen/logrus/internal/testutils"
+	. "github.com/17media/logrus"
+	. "github.com/17media/logrus/internal/testutils"
 )
 
 type TestHook struct {

--- a/hooks/syslog/syslog.go
+++ b/hooks/syslog/syslog.go
@@ -7,7 +7,7 @@ import (
 	"log/syslog"
 	"os"
 
-	"github.com/sirupsen/logrus"
+	"github.com/17media/logrus"
 )
 
 // SyslogHook to send logs via syslog.

--- a/hooks/syslog/syslog_test.go
+++ b/hooks/syslog/syslog_test.go
@@ -6,7 +6,7 @@ import (
 	"log/syslog"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/17media/logrus"
 )
 
 func TestLocalhostAddAndPrint(t *testing.T) {

--- a/hooks/test/test.go
+++ b/hooks/test/test.go
@@ -7,7 +7,7 @@ import (
 	"io/ioutil"
 	"sync"
 
-	"github.com/sirupsen/logrus"
+	"github.com/17media/logrus"
 )
 
 // Hook is a hook designed for dealing with logs in test scenarios.

--- a/hooks/test/test_test.go
+++ b/hooks/test/test_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/17media/logrus"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/testutils/testutils.go
+++ b/internal/testutils/testutils.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/sirupsen/logrus"
+	. "github.com/17media/logrus"
 
 	"github.com/stretchr/testify/require"
 )

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -53,7 +53,7 @@ func (f *JSONFormatter) Format(entry *Entry) ([]byte, error) {
 		switch v := v.(type) {
 		case error:
 			// Otherwise errors are ignored by `encoding/json`
-			// https://github.com/sirupsen/logrus/issues/137
+			// https://github.com/17media/logrus/issues/137
 			data[k] = v.Error()
 		default:
 			data[k] = v

--- a/level_test.go
+++ b/level_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/17media/logrus"
 	"github.com/stretchr/testify/require"
 )
 

--- a/logrus_test.go
+++ b/logrus_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	. "github.com/sirupsen/logrus"
-	. "github.com/sirupsen/logrus/internal/testutils"
+	. "github.com/17media/logrus"
+	. "github.com/17media/logrus/internal/testutils"
 )
 
 // TestReportCaller verifies that when ReportCaller is set, the 'func' field
@@ -40,7 +40,7 @@ func TestReportCallerWhenConfigured(t *testing.T) {
 		assert.Equal(t, "testWithCaller", fields["msg"])
 		assert.Equal(t, "info", fields["level"])
 		assert.Equal(t,
-			"github.com/sirupsen/logrus_test.TestReportCallerWhenConfigured.func3", fields["func"])
+			"github.com/17media/logrus_test.TestReportCallerWhenConfigured.func3", fields["func"])
 	})
 }
 
@@ -357,7 +357,7 @@ func TestNestedLoggingReportsCorrectCaller(t *testing.T) {
 	assert.Equal(t, "looks delicious", fields["msg"])
 	assert.Equal(t, "eating raw fish", fields["context"])
 	assert.Equal(t,
-		"github.com/sirupsen/logrus_test.TestNestedLoggingReportsCorrectCaller", fields["func"])
+		"github.com/17media/logrus_test.TestNestedLoggingReportsCorrectCaller", fields["func"])
 	cwd, err := os.Getwd()
 	require.NoError(t, err)
 	assert.Equal(t, filepath.ToSlash(fmt.Sprintf("%s/logrus_test.go:%d", cwd, line-1)), filepath.ToSlash(fields["file"].(string)))
@@ -388,7 +388,7 @@ func TestNestedLoggingReportsCorrectCaller(t *testing.T) {
 	assert.Equal(t, "The hardest workin' man in show business", fields["msg"])
 	assert.Nil(t, fields["fields.msg"], "should not have prefixed previous `msg` entry")
 	assert.Equal(t,
-		"github.com/sirupsen/logrus_test.TestNestedLoggingReportsCorrectCaller", fields["func"])
+		"github.com/17media/logrus_test.TestNestedLoggingReportsCorrectCaller", fields["func"])
 	require.NoError(t, err)
 	assert.Equal(t, filepath.ToSlash(fmt.Sprintf("%s/logrus_test.go:%d", cwd, line-1)), filepath.ToSlash(fields["file"].(string)))
 


### PR DESCRIPTION
## Description
- Import `17media/logrus` instead of `sirupsen/logrus`

## Motivation and Context
Go modules respects the dependency of dependency and finally, it uses [`sirupsen/logrus`](https://github.com/17media/logrus/blob/master/hooks/test/test_test.go#L9). In [`17media/api/apis/stats/stats_test.go`](https://github.com/17media/api/blob/master/apis/stats/stats_test.go#L61), we use `17media/logrus` and that's correct.

But it actually [adds the hook](https://github.com/17media/logrus/blob/master/hooks/test/test.go#L26) to the logger of `sirupsen/logrus`, not the logger of `17media/logrus`. Finally, the assertion failed.

And I think this test pass all the time because of the mechanism of vendor. I guess vendor will [replace](https://github.com/17media/api/blob/master/vendor/vendor.json#L2541) all `sirupsen/logrus` with `17media/logrus`.

## Remark
We were using the [commit `dad1cdd2cddebfe6c8994d72fcf1a487a650faf7`](https://github.com/17media/api/blob/9e6acb09fe6591968dc721f359d4af0a09985ea8/vendor/vendor.json#L2501) of `17media/logrus` and this commit is not on the master branch. It's actually on the branch `panic-message`. 

When we update `17media/logrus` from `dad1cdd2cddebfe6c8994d72fcf1a487a650faf7` to `d085a3f88068c5d64aa2b3bb585b56bc903c9223`, we actually update logrus from `v1.0.5` to `v1.3.0`.

The other issue is that now we have [different versions](https://github.com/17media/api/blob/master/vendor/vendor.json#L2549) of `17media/logrus` and `17media/logrus/hooks/test`. I suggest that we should make it consistent.